### PR TITLE
fix: compile error

### DIFF
--- a/src/edn_de.rs
+++ b/src/edn_de.rs
@@ -1,5 +1,5 @@
 use serde::de::{SeqAccess, Visitor};
-use serde::export::PhantomData;
+use std::marker::PhantomData;
 
 pub trait EDNVisitor<'de>: Sized + Visitor<'de> {
     type EDNValue;


### PR DESCRIPTION
```text
error[E0603]: module `export` is private
   --> src/edn_de.rs:2:12
    |
2   | use serde::export::PhantomData;
    |            ^^^^^^ private module
    |
note: the module `export` is defined here
```

Now it compiles :)